### PR TITLE
Error fixing and more flexibility using stdout and stderr

### DIFF
--- a/client.py
+++ b/client.py
@@ -10,7 +10,7 @@ s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.connect((host, port))
 
 while True:
-	recv_output = s.recv(16384) # Might be very long
+	recv_output = s.recv(524288) # Might be very long, this is 512KB
 	print(recv_output.decode())
 
 	inp = input("$ ")

--- a/server.py
+++ b/server.py
@@ -35,14 +35,14 @@ while True:
 	recv_command = conn.recv(2048) # Command must be < 2048 char
 	print(f"$ {recv_command.decode()}")
 
-	try:
-		call = subprocess.check_output(recv_command.decode(), shell=True)
-		"""
-		If there are any better function than check_output that if I enter a command but it is
-		an invalid command it still print the unsuccessful output pls contribute
-		"""
-		call = call.decode()
-		conn.sendall(call.encode())
-
-	except subprocess.CalledProcessError:
-		conn.sendall(f"'{recv_command.decode()}' is not recognized as an internal or external command, operable program or batch file.".encode())
+	call = subprocess.run(recv_command.decode(), shell=True, capture_output=True)
+	"""
+	If there are any better function than check_output that if I enter a command but it is
+	an invalid command it still print the unsuccessful output pls contribute
+	"""
+	output = call.stdout.decode()
+	error = call.stderr.decode()
+	if len(output) > 0 and len(error) <= 0:
+		conn.sendall(output.encode())
+	elif len(error) > 0 and len(output) <= 0:
+		conn.sendall(error.encode())


### PR DESCRIPTION
Those commits include:

- Using another function when calling subprocess (switch from `check_output()` to `run()`)
- Widening the command output and error that the client can read (from 16KB to 512KB)
- Printing stdout or stderr very flexible (if length of stdout <= 0 so it might be in stderr.