### PR TITLE
Update README.md, server.py

### DIFF
--- a/server.py
+++ b/server.py
@@ -37,7 +37,5 @@ while True:
 	call = subprocess.run(recv_command.decode(), shell=True, capture_output=True)
 	output = call.stdout.decode()
 	error = call.stderr.decode()
-	if len(output) > 0 and len(error) <= 0:
-		conn.sendall(output.encode())
-	elif len(error) > 0 and len(output) <= 0:
-		conn.sendall(error.encode())
+	realoutput = f"{output} {error}"
+	conn.sendall(realoutput.encode())


### PR DESCRIPTION
README.md: Updated details
server.py: print both command output and error
Today I read about Linux stdout and stderr and I saw that we need to print both stdout and stderr, because they can be both printed by a command. 
Updated server.py to print both of them
(Windows mostly print only stdout or stderr so last commit of server.py, I do only print stdout or stderr if one have the length > 1 and the other have the length <= 0, but Linux might print both of them after executing a command.)